### PR TITLE
Step3.3 - Fixing Compiler Errors and Warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ impl Hello {
         format!("Hello,  {}!", name)
     }
 
-    pub fn  hello__world() -> &'static str {
+    pub fn  hello__world() -> String {
         Hello::hello("wirld!".to_string())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ impl Hello {
     }
 
     pub fn hello_world() -> String {
-        Hello::hello("wirld!".to_string())
+        Hello::hello("world!".to_string())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ pub struct Hello;
 /// ```
 impl Hello {
     pub fn hello(name: String) -> String {
-        format!("Hello,  {}!", name)
+        format!("Hello, {}!", name)
     }
 
     pub fn hello_world() -> String {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ impl Hello {
         format!("Hello,  {}!", name)
     }
 
-    pub fn  hello__world() -> String {
+    pub fn hello__world() -> String {
         Hello::hello("wirld!".to_string())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ impl Hello {
         format!("Hello,  {}!", name)
     }
 
-    pub fn hello__world() -> String {
+    pub fn hello_world() -> String {
         Hello::hello("wirld!".to_string())
     }
 }
@@ -30,6 +30,6 @@ mod tests {
 
     #[test]
     fn hello_world() {
-        assert_eq!("Hello, world!", Hello::hello__world());
+        assert_eq!("Hello, world!", Hello::hello_world());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use worlds_simplest_kata::Hello;
 
 fn main() {
-    println!("{}", Hello::hello__world());
+    println!("{}", Hello::hello_world());
 }


### PR DESCRIPTION
Tackling two issues:

```rust
warning: method `hello__world` should have a snake case name
  --> src/lib.rs:22:12
   |
22 |     pub fn hello__world() -> String {
   |            ^^^^^^^^^^^^ help: convert the identifier to snake case: `hello_world`
   |
   = note: `#[warn(non_snake_case)]` on by default

warning: `worlds_simplest_kata` (lib) generated 1 warning
warning: `worlds_simplest_kata` (lib test) generated 1 warning (1 duplicate)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.03s
     Running unittests src/lib.rs (target/debug/deps/worlds_simplest_kata-8dbda2d597bc106c)

running 1 test
test tests::hello_world ... FAILED

failures:

---- tests::hello_world stdout ----

thread 'tests::hello_world' panicked at src/lib.rs:33:9:
assertion `left == right` failed
  left: "Hello, world!"
 right: "Hello,  wirld!!"
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    tests::hello_world

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

error: test failed, to rerun pass `--lib`
```